### PR TITLE
layout: add safe boundary for small screens

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,8 +160,7 @@ fn Main() -> Element {
 
     rsx! {
         div {
-            class: "flex flex-col flex-1 h-screen bg-zinc-950 text-zinc-100 font-sans antialiased",
-
+            class: "flex flex-col flex-1 min-h-screen bg-zinc-950 text-zinc-100 font-sans antialiased pt-safe pb-safe",
             main {
                 class: "flex-1 flex flex-col overflow-hidden",
                 Outlet::<Route> {}


### PR DESCRIPTION
tested on iphone and android, fixed observed overflow issue