### PR TITLE
samsung: use textarea to allow copy/paste contact record

### DIFF
--- a/apps/footnote-ui/src/components/share_my_contact_modal.rs
+++ b/apps/footnote-ui/src/components/share_my_contact_modal.rs
@@ -75,8 +75,8 @@ pub fn ShareMyContactModal() -> Element {
                     }
                 }
                 div { class: "p-6 flex-1 min-h-0 flex flex-col",
-                    pre {
-                        class: "flex-1 w-full px-4 py-3 bg-zinc-950 border border-zinc-800 rounded-lg text-xs font-mono text-zinc-300 overflow-auto mb-4 whitespace-pre overflow-x-auto",
+                    textarea {
+                        class: "flex-1 w-full px-4 py-3 bg-zinc-950 border border-zinc-800 rounded-lg text-xs font-mono text-zinc-300 resize-none focus:border-zinc-600 focus:ring-1 focus:ring-zinc-600 mb-4",
                         "{user_record_json}"
                     }
 


### PR DESCRIPTION
testing in the samsung lab, copy/paste only works for a regular textarea. "select-all" and readonly both seemed to remove the ability for copying the record.